### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -274,7 +274,8 @@ write_env_file() {
 #   systemctl restart openblockperf
 
 # -----------------------------------------------------------------------
-# Required: API key issued at https://openblockperf.cardano.org
+# Required: API key issued with the 'blockperf register' command
+# registration requires the pool bech32 id and the calidus secret (s)key
 # -----------------------------------------------------------------------
 OPENBLOCKPERF_API_KEY=
 
@@ -316,6 +317,7 @@ Wants=network-online.target
 Type=simple
 User=${SERVICE_USER}
 Group=${SERVICE_GROUP}
+WorkingDirectory=${INSTALL_DIR}
 EnvironmentFile=${ENV_FILE}
 ExecStart=${bin} run
 Restart=on-failure


### PR DESCRIPTION
Added installer modes and options:
--install (default)
--reinstall
--remove
--yes / -y for non-interactive confirmations
--purge (with --remove) to also delete env file

Added robust service identity resolution:
- SERVICE_USER/SERVICE_GROUP env vars still take precedence.
- If not set, script now resolves user from SUDO_USER, then logname, then whoami.
- If resolved user is empty or root, script prompts interactively for a non-root user.
- Group is auto-derived from id -gn <user> when not set. Both user and group are now strictly validated (id, getent group).

Added more initial sanity checks:
- root check
- Linux check
- required commands check (id, getent, mkdir, rm, chmod, chown, install) systemd presence check

Made destructive behavior safer:
- Normal install no longer blindly wipes install directory.
- Existing install dir on --install now errors with guidance to use --reinstall.
- --reinstall and --remove now ask for confirmation (unless --yes). service stop/disable logic added for reinstall/remove paths.

Improved service handling:
- unit name now derived from SERVICE_FILE basename (UNIT_NAME) instead of hardcoded openblockperf.service.